### PR TITLE
Set bucket ownership to BucketOwnerEnforced instead of using private ACL

### DIFF
--- a/modules/canary-infra/main.tf
+++ b/modules/canary-infra/main.tf
@@ -42,9 +42,11 @@ resource "aws_s3_bucket_lifecycle_configuration" "canaries_reports_bucket_lifecy
   }
 }
 
-resource "aws_s3_bucket_acl" "canaries_reports_bucket_acl" {
+resource "aws_s3_bucket_ownership_controls" "canaries_reports_bucket_ownership_controls" {
   bucket = aws_s3_bucket.canaries_reports_bucket.bucket
-  acl    = "private"
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
 }
 
 resource "aws_s3_bucket_public_access_block" "canaries_reports_bucket_block_public_access" {


### PR DESCRIPTION
With new bucket is not possible to set ACL to private because S3 assigns a BucketOwnerEnforced ownership to the newly created bucket.

With this change we ensure that the ownership is correctly set.

From AWS docs
"By default, Object Ownership is set to the Bucket owner enforced setting, and all ACLs are disabled. When ACLs are disabled, the bucket owner owns all the objects in the bucket and manages access to them exclusively by using access-management policies."


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
